### PR TITLE
FIX-000: Allow 5 characters in github PR title prefix

### DIFF
--- a/.github/workflows/util-pr-checks.yml
+++ b/.github/workflows/util-pr-checks.yml
@@ -14,7 +14,7 @@ jobs:
       - name: "PR Title Check"
         uses: Slashgear/action-check-pr-title@3dc601455ee2e3f5bf1e8e7cf31261ebdd4e1756
         with:
-          regexp: '^[A-Z]{1,4}-[0-9]{1,5}'
+          regexp: '^[A-Z]{1,5}-[0-9]{1,5}'
 
       # Add the type of PR label, defined in ../labeler.yml
       - name: "PR Type Label"


### PR DESCRIPTION
[App Service Squad](https://zaidi-bank.atlassian.net/jira/software/projects/APSRV/boards/14) abbreviation is "APSRV" which is 5 characters, thus I propose to extend utility check to allow up to 5 characters